### PR TITLE
Added the hover color checker at the demo page

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -97,6 +97,10 @@ LI {
     margin-bottom: 1em;
     border: 1px solid #DDD;
     }
+    .demo-icon:hover {
+        color: #FFF;
+        background: #000;
+        }
     .demo-icon--svg {
         margin-right: 3em;
         }


### PR DESCRIPTION
There can be:

- icons with `currentColor` used
- icons that are prepared to be over dark backgrounds.

This commit adds a way to test those two variants just by hovering the result containers, so you could see if the color is inherited from the `currentColor` and if there are any white elements that you could see over dark background.