### PR TITLE
Sort icons alphabetically based on their name on a demo page

### DIFF
--- a/tasks/svg_fallback.js
+++ b/tasks/svg_fallback.js
@@ -343,6 +343,11 @@ module.exports = function(grunt) {
                 iconSvgTemplate = grunt.file.read(templatesFolder + '/icon--svg.html'),
                 iconItemTemplate = grunt.file.read(templatesFolder + '/icon--item.html');
 
+            // Sort icons alphabetically based on their name
+            items.sort(function(a, b){
+                return a.name.localeCompare(b.name);
+            });
+
             for (var i = 0; i < items.length; i++) {
                 var item = items[i];
                 var iconId = item.name;


### PR DESCRIPTION
Right now all the icons are displayed on a demo page in a somewhat random order, we can sort them by their names, so everything would look more shiny :sparkles: 