### PR TITLE
Option to disable PNG fallback and build SVG library only

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ Default value: `10`
 
 List of spritesmith options is here: [npmjs.org/package/spritesmith](https://www.npmjs.org/package/spritesmith)
 
+#### options.pngfallback
+Type: `Bool`
+
+Default value: `true`
+
+Set `false` if you need SVG library only, without PNG fallback.
+
 #### options.svgclass
 Type: `String`
 

--- a/tasks/svg_fallback.js
+++ b/tasks/svg_fallback.js
@@ -35,6 +35,7 @@ module.exports = function(grunt) {
             folder = this.data.folder,
             options = this.options(),
             debug = options.debug,
+            pngfallback = typeof options.pngfallback === 'boolean' ? options.pngfallback : true,
             svgclass = options.svgclass ? options.svgclass : 'svg',
             svgstyle  = options.svgstyle ? options.svgstyle : '',
             usei8class = options.usei8class ? options.usei8class : false,
@@ -107,7 +108,10 @@ module.exports = function(grunt) {
             return;
         }
         //return null;
-        createPngByFoldersAsync();
+
+        if (pngfallback) {
+            createPngByFoldersAsync();
+        }
 
         // 4. Create sprite from png, write CSS
         //------------------------------------------


### PR DESCRIPTION
We use `svg-fallback` to build SVG library only. So there is usefull option to disable svg-to-png convertion.